### PR TITLE
Minor perf opt: remove over-split + redundant join

### DIFF
--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -17,9 +17,7 @@ function find(key, obj) {
         return obj[key];
     }
     if (key.includes('.')) { // e.g. 'a.b.c'
-        key = key.split('.');
-        let top = key[0]; // e.g. 'a'
-        let sub = key.slice(1).join('.'); // e.g. 'b.c'
+        const [ top, sub ] = key.split('.', 1); // e.g. [ 'a', 'b.c' ]
         return find(sub, obj[top]);
     }
 }


### PR DESCRIPTION
`String.prototype.split` takes an optional 2nd arg which limits how many times you split i.e. the length of the array returned